### PR TITLE
chore: Android GH actions build + various fixes

### DIFF
--- a/.github/workflows/.env-android-arm
+++ b/.github/workflows/.env-android-arm
@@ -1,0 +1,12 @@
+export ARCH=arm
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export ANDROID_HOME=/opt/android-sdk
+export ANDROID_NDK_HOME=/opt/android-sdk/ndk/26.1.10909125
+export SDK_PATH=/opt/android-sdk
+export QT_PATH=/opt/qt/6.8.3
+export QT_HOST_PATH=/opt/qt/6.8.3/gcc_64
+export QT_ANDROID_PATH=/opt/qt/6.8.3/android_armv7
+export PATH=/opt/qt/6.8.3/android_armv7/bin:/opt/qt/6.8.3/gcc_64/bin:/opt/qt/6.8.3/gcc_64/libexec:/opt/qt/6.8.3/android_armv7/libexec:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools:/usr/bin:/bin:/usr/local/bin
+export PKG_CONFIG_PATH=/opt/qt/6.8.3/android_armv7/lib/pkgconfig
+export ANDROID_ABI=armv7a
+export USE_SYSTEM_NIM=1

--- a/.github/workflows/.env-android-arm64
+++ b/.github/workflows/.env-android-arm64
@@ -1,0 +1,12 @@
+export ARCH=arm64
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export ANDROID_HOME=/opt/android-sdk
+export ANDROID_NDK_HOME=/opt/android-sdk/ndk/26.1.10909125
+export SDK_PATH=/opt/android-sdk
+export QT_PATH=/opt/qt/6.8.3
+export QT_HOST_PATH=/opt/qt/6.8.3/gcc_64
+export QT_ANDROID_PATH=/opt/qt/6.8.3/android_arm64_v8a
+export PATH=/opt/qt/6.8.3/android_arm64_v8a/bin:/opt/qt/6.8.3/gcc_64/bin:/opt/qt/6.8.3/gcc_64/libexec:/opt/qt/6.8.3/android_arm64_v8a/libexec:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools:/usr/bin:/bin:/usr/local/bin
+export PKG_CONFIG_PATH=/opt/qt/6.8.3/android_arm64_v8a/lib/pkgconfig
+export ANDROID_ABI=arm64-v8a
+export USE_SYSTEM_NIM=1

--- a/.github/workflows/.env-android-x86
+++ b/.github/workflows/.env-android-x86
@@ -1,0 +1,12 @@
+export ARCH=x86
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export ANDROID_HOME=/opt/android-sdk
+export ANDROID_NDK_HOME=/opt/android-sdk/ndk/26.1.10909125
+export SDK_PATH=/opt/android-sdk
+export QT_PATH=/opt/qt/6.8.3
+export QT_HOST_PATH=/opt/qt/6.8.3/gcc_64
+export QT_ANDROID_PATH=/opt/qt/6.8.3/android_x86
+export PATH=/opt/qt/6.8.3/android_x86/bin:/opt/qt/6.8.3/gcc_64/bin:/opt/qt/6.8.3/gcc_64/libexec:/opt/qt/6.8.3/android_x86/libexec:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools:/usr/bin:/bin:/usr/local/bin
+export PKG_CONFIG_PATH=/opt/qt/6.8.3/android_x86/lib/pkgconfig
+export ANDROID_ABI=x86
+export USE_SYSTEM_NIM=1

--- a/.github/workflows/.env-android-x86_64
+++ b/.github/workflows/.env-android-x86_64
@@ -1,0 +1,12 @@
+export ARCH=x86_64
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export ANDROID_HOME=/opt/android-sdk
+export ANDROID_NDK_HOME=/opt/android-sdk/ndk/26.1.10909125
+export SDK_PATH=/opt/android-sdk
+export QT_PATH=/opt/qt/6.8.3
+export QT_HOST_PATH=/opt/qt/6.8.3/gcc_64
+export QT_ANDROID_PATH=/opt/qt/6.8.3/android_x86_64
+export PATH=/opt/qt/6.8.3/android_x86_64/bin:/opt/qt/6.8.3/gcc_64/bin:/opt/qt/6.8.3/gcc_64/libexec:/opt/qt/6.8.3/android_x86_64/libexec:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools:/usr/bin:/bin:/usr/local/bin
+export PKG_CONFIG_PATH=/opt/qt/6.8.3/android_x86_64/lib/pkgconfig
+export ANDROID_ABI=x86_64
+export USE_SYSTEM_NIM=1

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,57 @@
+name: Android Build APK
+
+on:
+  workflow_dispatch
+
+jobs:
+  android-build:
+    runs-on: ubuntu-latest
+    name: Build Android APK
+    container:
+      image: carlonluca/qt-dev:6.8.3
+
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+      ANDROID_HOME: /opt/android-sdk
+      ANDROID_NDK_HOME: /opt/android-sdk/ndk/26.1.10909125
+      SDK_PATH: /opt/android-sdk
+      ARCH: arm64
+      QT_PATH: /opt/qt/6.8.3
+      QT_HOST_PATH: /opt/qt/6.8.3/gcc_64
+      QT_ANDROID_PATH: /opt/qt/6.8.3/android_arm64_v8a
+      PATH: /opt/qt/6.8.3/android_arm64_v8a/bin:/opt/qt/6.8.3/gcc_64/bin:/opt/qt/6.8.3/gcc_64/libexec:/opt/qt/6.8.3/android_arm64_v8a/libexec:/opt/android-sdk/emulator:/opt/android-sdk/tools:/opt/android-sdk/tools/bin:/opt/android-sdk/platform-tools:/usr/bin:/bin:/usr/local/bin
+      PKG_CONFIG_PATH: /opt/qt/6.8.3/android_arm64_v8a/lib/pkgconfig
+      ANDROID_ABI: arm64-v8a
+      USE_SYSTEM_NIM: 1
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -yq curl
+
+          curl https://nim-lang.org/choosenim/init.sh -sSf | sh
+          $HOME/.nimble/bin/choosenim 2.0.12
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+          cache-dependency-path: go.sum
+
+      - name: Install Go tools
+        run: |
+          go install github.com/go-bindata/go-bindata/v3/go-bindata@latest
+          go install go.uber.org/mock/mockgen@v0.4.0
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
+
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build Android APK
+        run: |
+          make V=3
+

--- a/ContainerBuilds.mk
+++ b/ContainerBuilds.mk
@@ -1,0 +1,27 @@
+-include ./scripts/Common.mk
+
+# Supported architectures
+# arm64: arm64-v8a
+# arm: armeabi-v7a
+# x86_64: x86_64
+# x86: x86
+ARCH?=$(shell uname -m)
+
+$(TARGET): $(STATUS_DESKTOP_NIM_FILES) $(STATUS_DESKTOP_UI_FILES) $(STATUS_Q_FILES) $(STATUS_Q_UI_FILES) $(STATUS_GO_FILES) $(DOTHERSIDE_FILES) $(OPENSSL_FILES) $(QRCODEGEN_FILES) $(PCRE_FILES) $(WRAPPER_APP_FILES)
+	@echo "Building GitHub task"
+	act -j android-build --container-architecture linux/amd64 --env-file $(ROOT_DIR)/.github/workflows/.env-android-$(ARCH) linux/amd64 -r
+	@echo "Copying target"
+	@mkdir -p $(BIN_PATH)
+	@docker cp $(shell docker ps -a --format '{{.Names}}' | grep Android-Build-APK):$(TARGET) $(BIN_PATH)
+
+
+run: $(TARGET)
+	@echo "Running GitHub task"
+	@APP=$(TARGET) QT_VERSION=$(QT_VERSION) ADB=$(shell which adb) EMULATOR=$(shell which emulator) $(RUN_SCRIPT)
+
+clean:
+	@echo "Cleaning GitHub task"
+	@docker rm -f $(shell docker ps -a --format '{{.Names}}' | grep Android-Build-APK)
+	@rm -rf $(ROOT_DIR)/bin $(ROOT_DIR)/build $(ROOT_DIR)/lib
+
+default: $(TARGET)

--- a/ContainerBuilds.mk
+++ b/ContainerBuilds.mk
@@ -17,7 +17,7 @@ $(TARGET): $(STATUS_DESKTOP_NIM_FILES) $(STATUS_DESKTOP_UI_FILES) $(STATUS_Q_FIL
 
 run: $(TARGET)
 	@echo "Running GitHub task"
-	@APP=$(TARGET) QT_VERSION=$(QT_VERSION) ADB=$(shell which adb) EMULATOR=$(shell which emulator) $(RUN_SCRIPT)
+	@APP=$(TARGET) QT_VERSION=$(QT_VERSION) ADB=$(shell which adb) EMULATOR=$(shell which emulator) AVDMANAGER=$(shell which avdmanager) SDKMANAGER=$(shell which sdkmanager) $(RUN_SCRIPT)
 
 clean:
 	@echo "Cleaning GitHub task"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Status Tablet Build System
 
 This repository contains the build system for Status Tablet, supporting both iOS and Android platforms with Qt5 and Qt6 compatibility.
+Cross-compilation is currently supported on MacOs and Linux. Windows is not supported. The dev setup runs well on WSL with Windows emulator.
 
 ## Table of Contents
 - [Quick Start Guide (Container Builds) - Android](#quick-start-guide-container-builds)
@@ -19,133 +20,42 @@ This section is for users who want to get up and running quickly with minimal te
 - ADB (Android Debug Bridge)
 - Android Emulator
 
-### One-Time Setup
+### Quick setup - android
 
-1. **Install Docker:**
+1. **Install dependencies:**
+   ```bash
+    git clone <repository-url>
+    cd <repository-name>
+    git submodule update --init --recursive
+   ```
+
    ```bash
    # macOS
-   brew install docker
+   brew install docker act android-platform-tools android-commandlinetools
+   ```
 
+   ```bash
    # Ubuntu
    sudo apt-get update
-   sudo apt-get install docker.io
-   
-   # Windows
-   # Download and install Docker Desktop from https://www.docker.com/products/docker-desktop
-   ```
-
-2. **Install act:**
-   ```bash
-   # macOS
-   brew install act
-
-   # Ubuntu - installing in /bin
+   sudo apt install android-sdk-common google-android-emulator-installer docker.io
+   # Installing act in /bin
    (cd /;curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash)
-   
-   # Windows - using Chocolatey
-   choco install act-cli
-   # or with scoop
-   scoop install act
-   # or download the binary directly from https://github.com/nektos/act/releases
    ```
 
-3. **Install Android tools:**
-
-   Can be installed through Android Studio or following the steps below
-
-   ```bash
-   # macOS
-   brew install android-platform-tools
-
-   # Ubuntu
-   sudo apt-get install android-tools-adb android-tools-fastboot
-   
-   # Windows - using Chocolatey
-   choco install adb
-   # or download the SDK Platform Tools from https://developer.android.com/studio/releases/platform-tools
-   ```
-
-4. **Set up Android environment:**
-   ```bash
-   # For macOS, add to ~/.zshrc or ~/.bash_profile:
-   export ANDROID_HOME=$HOME/Library/Android/sdk
-   export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
-
-   # For Ubuntu, add to ~/.bashrc:
-   export ANDROID_HOME=$HOME/Android/Sdk
-   export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
-
-   # For Windows, add to System Environment Variables:
-   # ANDROID_HOME = C:\Users\<username>\AppData\Local\Android\Sdk
-   # Add to PATH: %ANDROID_HOME%\platform-tools;%ANDROID_HOME%\emulator
-   
-   # After adding to your shell config, reload it:
-   source ~/.zshrc  # or ~/.bash_profile or ~/.bashrc
-   # For Windows, restart your terminal or command prompt
-   ```
-
-5. **Verify installation:**
+2. **Verify installation:**
    ```bash
    adb --version
    emulator --version
+   avdmanager --version
+   sdkmanager --version
    ```
 
-### Building and Running the App
-
-1. **Clone the repository:**
+2. **Running the app**
    ```bash
-   git clone <repository-url>
-   cd <repository-name>
-   git submodule update --init --recursive
-   ```
-
-2. **Set the target architecture (optional):**
-   ```bash
-   # Choose one of: arm64, arm, x86_64, x86
-   
-   # macOS/Linux
-   export ARCH=arm64
-   
-   # Windows (Command Prompt)
-   set ARCH=arm64
-   
-   # Windows (PowerShell)
-   $env:ARCH = "arm64"
-   ```
-
-3. **Build the APK:**
-   ```bash
-   # macOS/Linux
-   make -f ContainerBuilds.mk
-   
-   # Windows
-   # If you have GNU Make installed
-   make -f ContainerBuilds.mk
-   
-   # Alternatively, with Docker directly on Windows
-   docker run --rm -it -v ${PWD}:/workspace -w /workspace -e ARCH=%ARCH% android-builder:latest /bin/bash -c "make android"
-   ```
-
-4. **Run the app:**
-   ```bash
-   # macOS/Linux
+   # Linux and MacOS
    make -f ContainerBuilds.mk run
-   
-   # Windows
-   # If you have GNU Make installed
-   make -f ContainerBuilds.mk run
-   
-   # Alternatively using adb directly
-   adb install -r bin/Status-tablet.apk
-   adb shell am start -n im.status.tablet/org.qtproject.qt.android.bindings.QtActivity
    ```
 
-5. **Cleaning:**
-   ```bash
-   # macOS/Linux/Windows
-   make -f ContainerBuilds.mk clean
-   ```
-ß
 ### What Happens Behind the Scenes
 - The build process uses GitHub Actions containers to ensure consistent builds
 - All required tools and dependencies are provided by the container
@@ -217,8 +127,8 @@ This section is for developers who want full control over the build environment.
 
 ### Android Development Setup
 
-#### Prerequisites
-- JDK 11 (17 for Qt6)
+#### Prerequisites - can be installed using the Android Studio
+- JDK 17 (11 for Qt5)
 - Android SDK
 - Android NDK (21.3.6528147 for Qt5, 26.1.10909125 for Qt6)
 - Android emulator
@@ -238,11 +148,6 @@ This section is for developers who want full control over the build environment.
 
    # Add Android tools to PATH
    export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
-
-   # Set target architecture
-   export OS=android
-   export ARCH=arm64  # arm64-v8a
-   export ANDROID_API=28
    ```
 
 2. **Install Qt for Android:**
@@ -257,12 +162,12 @@ This section is for developers who want full control over the build environment.
 
    # For Qt6 (includes desktop tools)
    # arm host
-   aqt install-qt mac android 6.8.3 android_arm64_v8a -m all --autodesktop
+   aqt install-qt mac android 6.8.3 android_arm64_v8a -O ${QT_INSTALL_DIR} -m all --autodesktop
    # x64 host
-   aqt install-qt mac android 6.8.3 android_x86_64 -m all --autodesktop
+   aqt install-qt mac android 6.8.3 android_x86_64 -O ${QT_INSTALL_DIR}  -m all --autodesktop
    # optional
-   aqt install-qt mac android 6.8.3 android_x86 -m all
-   aqt install-qt mac android 6.8.3 android_armv7 -m all
+   aqt install-qt mac android 6.8.3 android_x86 -O ${QT_INSTALL_DIR}  -m all
+   aqt install-qt mac android 6.8.3 android_armv7 -O ${QT_INSTALL_DIR} -m all
 
    # Add Qt to PATH. Qt6 needs both ios bin and host libexec
    export QTDIR_BIN=${QT_INSTALL_DIR}/{QT_VERSION}/ios/bin
@@ -270,7 +175,7 @@ This section is for developers who want full control over the build environment.
    export PATH=${QTDIR_BIN}:${QT_HOST_LIBEXEC}:${PATH}
    ```
 
-3. **Create Android Virtual Device (if needed):**
+3. **Create Android Virtual Device (optional - one will be created by default):**
    ```bash
    # It's best to choose the host arch
    avdmanager create avd -n "Test_avd_x64" -k "system-images;android-Baklava;google_apis_playstore;x86_64" -d 70
@@ -406,5 +311,3 @@ When contributing to the build system:
 2. Qt6 compatibility is mandatory. Qt5 is nice to have for now
 3. Update this README if necessary
 4. Follow the existing build system patterns
-
-

--- a/README.md
+++ b/README.md
@@ -1,154 +1,410 @@
-# Qt Version Compatibility
+# Status Tablet Build System
 
-This project supports both Qt5 and Qt6. The build system automatically detects your Qt version and adjusts accordingly.
+This repository contains the build system for Status Tablet, supporting both iOS and Android platforms with Qt5 and Qt6 compatibility.
 
-## Building with Qt5 (Default)
+## Table of Contents
+- [Quick Start Guide (Container Builds) - Android](#quick-start-guide-container-builds)
+- [Developer Setup Guide](#developer-setup-guide)
+- [Build System Documentation](#build-system-documentation)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+
+## Quick Start Guide (Container Builds)
+
+This section is for users who want to get up and running quickly with minimal technical setup.
+
+### Prerequisites
+- Docker
+- [act](https://github.com/nektos/act) (GitHub Actions local runner)
+- ADB (Android Debug Bridge)
+- Android Emulator
+
+### One-Time Setup
+
+1. **Install Docker:**
+   ```bash
+   # macOS
+   brew install docker
+
+   # Ubuntu
+   sudo apt-get update
+   sudo apt-get install docker.io
+   
+   # Windows
+   # Download and install Docker Desktop from https://www.docker.com/products/docker-desktop
+   ```
+
+2. **Install act:**
+   ```bash
+   # macOS
+   brew install act
+
+   # Ubuntu - installing in /bin
+   (cd /;curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash)
+   
+   # Windows - using Chocolatey
+   choco install act-cli
+   # or with scoop
+   scoop install act
+   # or download the binary directly from https://github.com/nektos/act/releases
+   ```
+
+3. **Install Android tools:**
+
+   Can be installed through Android Studio or following the steps below
+
+   ```bash
+   # macOS
+   brew install android-platform-tools
+
+   # Ubuntu
+   sudo apt-get install android-tools-adb android-tools-fastboot
+   
+   # Windows - using Chocolatey
+   choco install adb
+   # or download the SDK Platform Tools from https://developer.android.com/studio/releases/platform-tools
+   ```
+
+4. **Set up Android environment:**
+   ```bash
+   # For macOS, add to ~/.zshrc or ~/.bash_profile:
+   export ANDROID_HOME=$HOME/Library/Android/sdk
+   export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
+
+   # For Ubuntu, add to ~/.bashrc:
+   export ANDROID_HOME=$HOME/Android/Sdk
+   export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
+
+   # For Windows, add to System Environment Variables:
+   # ANDROID_HOME = C:\Users\<username>\AppData\Local\Android\Sdk
+   # Add to PATH: %ANDROID_HOME%\platform-tools;%ANDROID_HOME%\emulator
+   
+   # After adding to your shell config, reload it:
+   source ~/.zshrc  # or ~/.bash_profile or ~/.bashrc
+   # For Windows, restart your terminal or command prompt
+   ```
+
+5. **Verify installation:**
+   ```bash
+   adb --version
+   emulator --version
+   ```
+
+### Building and Running the App
+
+1. **Clone the repository:**
+   ```bash
+   git clone <repository-url>
+   cd <repository-name>
+   git submodule update --init --recursive
+   ```
+
+2. **Set the target architecture (optional):**
+   ```bash
+   # Choose one of: arm64, arm, x86_64, x86
+   
+   # macOS/Linux
+   export ARCH=arm64
+   
+   # Windows (Command Prompt)
+   set ARCH=arm64
+   
+   # Windows (PowerShell)
+   $env:ARCH = "arm64"
+   ```
+
+3. **Build the APK:**
+   ```bash
+   # macOS/Linux
+   make -f ContainerBuilds.mk
+   
+   # Windows
+   # If you have GNU Make installed
+   make -f ContainerBuilds.mk
+   
+   # Alternatively, with Docker directly on Windows
+   docker run --rm -it -v ${PWD}:/workspace -w /workspace -e ARCH=%ARCH% android-builder:latest /bin/bash -c "make android"
+   ```
+
+4. **Run the app:**
+   ```bash
+   # macOS/Linux
+   make -f ContainerBuilds.mk run
+   
+   # Windows
+   # If you have GNU Make installed
+   make -f ContainerBuilds.mk run
+   
+   # Alternatively using adb directly
+   adb install -r bin/Status-tablet.apk
+   adb shell am start -n im.status.tablet/org.qtproject.qt.android.bindings.QtActivity
+   ```
+
+5. **Cleaning:**
+   ```bash
+   # macOS/Linux/Windows
+   make -f ContainerBuilds.mk clean
+   ```
+ß
+### What Happens Behind the Scenes
+- The build process uses GitHub Actions containers to ensure consistent builds
+- All required tools and dependencies are provided by the container
+- The built APK is copied from the container to the local `bin` directory
+
+## Developer Setup Guide
+
+This section is for developers who want full control over the build environment.ß
+
+### Prerequisites
+- Git
+- Python 3.x
+- Qt (5.15.2 or 6.8.3)
+- Platform-specific requirements (see below)
+
+### Common Setup
+
+1. **Clone the repository and submodules:**
+   ```bash
+   git clone <repository-url>
+   cd <repository-name>
+   git submodule update --init --recursive
+   ```
+
+2. **Install Qt using aqtinstall:**
+   ```bash
+   pip3 install -U pip
+   pip3 install aqtinstall
+   ```
+
+### iOS Development Setup
+
+#### Prerequisites
+- Xcode
+- iPad Pro simulator
+- Qt 5.15.2 or 6.8.3 for iOS
+
+#### Setup Steps
+
+1. **Install Qt for iOS:**
+   ```bash
+   # Set your Qt installation directory
+   export QT_INSTALL_DIR=/path/to/qt
+   export QT_VERSION=6.8.3
+
+   # Install Qt 5.15.2 (or 6.8.3 for Qt6)
+   aqt install-qt mac ios ${QT_VERSION} -O ${QT_INSTALL_DIR} -m all --autodesktop
+
+   # If the above fails on arm64, try:
+   arch -x86_64 aqt install-qt mac ios ${QT_VERSION} -O ${QT_INSTALL_DIR} -m all --autodesktop
+
+   # Add Qt to PATH. Qt6 needs both ios bin and host libexec
+   export QTDIR_BIN=${QT_INSTALL_DIR}/{QT_VERSION}/ios/bin
+   export QT_HOST_LIBEXEC=${QT_INSTALL_DIR}/[**hostTarget**]/libexec
+   export PATH=${QTDIR_BIN}:${QT_HOST_LIBEXEC}:${PATH}
+   ```
+
+2. **Set environment variables (optional):**
+   ```bash
+   export ARCH=arm64  # For device build; Defaults to x86_64 - simulator
+   export IPHONE_SDK=iphoneos  # or iphonesimulator; Defaults to iphonesimulator
+   export IOS_TARGET=16  # Defaults to min qt support
+   ```
+
+3. **Build and run:**
+   ```bash
+   make run
+   ```
+
+### Android Development Setup
+
+#### Prerequisites
+- JDK 11 (17 for Qt6)
+- Android SDK
+- Android NDK (21.3.6528147 for Qt5, 26.1.10909125 for Qt6)
+- Android emulator
+- Android command-line tools
+
+#### Setup Steps
+
+1. **Set environment variables:**
+   ```bash
+   # Set Java home
+   export JAVA_HOME=/path/to/jdk
+
+   # Set Android SDK and NDK paths
+   export ANDROID_HOME=/path/to/android-sdk
+   export ANDROID_NDK_HOME=/path/to/android-ndk
+   export SDK_PATH="$ANDROID_HOME"
+
+   # Add Android tools to PATH
+   export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+   # Set target architecture
+   export OS=android
+   export ARCH=arm64  # arm64-v8a
+   export ANDROID_API=28
+   ```
+
+2. **Install Qt for Android:**
+   Note: It's best to install the qt architecture matching the system architecture
+
+   ```bash
+   # Set your Qt installation directory
+   export QT_INSTALL_DIR=/path/to/qt
+
+   # Install Qt 5.15.2
+   aqt install-qt mac android 5.15.2 -O ${QT_INSTALL_DIR}
+
+   # For Qt6 (includes desktop tools)
+   # arm host
+   aqt install-qt mac android 6.8.3 android_arm64_v8a -m all --autodesktop
+   # x64 host
+   aqt install-qt mac android 6.8.3 android_x86_64 -m all --autodesktop
+   # optional
+   aqt install-qt mac android 6.8.3 android_x86 -m all
+   aqt install-qt mac android 6.8.3 android_armv7 -m all
+
+   # Add Qt to PATH. Qt6 needs both ios bin and host libexec
+   export QTDIR_BIN=${QT_INSTALL_DIR}/{QT_VERSION}/ios/bin
+   export QT_HOST_LIBEXEC=${QT_INSTALL_DIR}/[**hostTarget**]/libexec
+   export PATH=${QTDIR_BIN}:${QT_HOST_LIBEXEC}:${PATH}
+   ```
+
+3. **Create Android Virtual Device (if needed):**
+   ```bash
+   # It's best to choose the host arch
+   avdmanager create avd -n "Test_avd_x64" -k "system-images;android-Baklava;google_apis_playstore;x86_64" -d 70
+   ```
+
+4. **Build and run:**
+   ```bash
+   make run
+   ```
+
+## Build System Documentation
+
+### Environment Variables
+
+The build system uses several environment variables to control the build process:
+
+#### Build Control Variables
+- `USE_SYSTEM_NIM=1`: Use system-installed Nim instead of building from source. Make sure `nim` and `nimble` are available
+
+#### Platform Configuration
+- `OS`: Target platform (`ios` or `android`) - qmake driven
+- `ARCH`: Target architecture - defaults to host arch for android and `x86_64` for ios simulator
+  - iOS: `arm64` (device) or `x86_64` (simulator)
+  - Android: `arm64` (arm64-v8a), `arm` (armeabi-v7a), `x86_64`, or `x86`
+- `PATH`: Should contain the path to Android or iOS Qt installation `bin` folder
+
+#### Android-specific Variables
+- `ANDROID_API`: Android API level (default: 28)
+- `ANDROID_NDK_HOME`: Path to Android NDK
+- `ANDROID_HOME`: Path to Android SDK
+- `SDK_PATH`: Path to Android SDK (used by some build scripts)
+- `JAVA_HOME`: Path to JDK installation
+
+#### iOS-specific Variables
+- `IPHONE_SDK`: iOS SDK to use (`iphoneos` or `iphonesimulator`)
+- `IOS_TARGET`: Minimum iOS version (12 for Qt5, 16 for Qt6)
+
+### Qt Version Compatibility
+
+#### Qt5 (Default)
 - iOS minimum deployment target: iOS 12
-- IOS simulator: Ipad pro
+- iOS simulator: iPad Pro
 - Android target: Android 31
-- Android ndk: 21.3.6528147
+- Android NDK: 21.3.6528147
 - Android API: 28
 - JDK: 11
 
-## Building with Qt6
+#### Qt6
 - iOS minimum deployment target: iOS 16
-- IOS simulator: Ipad pro
+- iOS simulator: iPad Pro
 - Android target: Android 35
-- Android ndk: 26.1.10909125
+- Android NDK: 26.1.10909125
 - Android API: 28
 - JDK: 17
 
-# IOS
+### Directory Structure
+- `bin/`: Final build outputs
+- `lib/`: Compiled libraries
+- `build/`: Intermediate build files
+- `scripts/`: Build scripts and utilities
 
-### Running the app
+### Key Components
+- Status Go
+- StatusQ
+- DOtherSide
+- OpenSSL
+- QRCodeGen
+- PCRE
+- Nim Status Client
 
-#### Prerequisites:
-- Make sure status-desktop can be built
-- Qt 5.15.2 for IOS or Qt 6.8.3 for IOS
-- Python
-- Clone submodules
-```
-  git submodule update --init --recursive
-```
-- Xcode
-- Ipad pro simulator
+### Build Targets
+- `make`: Build all components
+- `make clean`: Clean all build artifacts
+- `make run`: Build and run the application
+- Platform-specific targets (e.g., `make iosdevice`)
 
-#### Installing qt
-```
-  pip3 install -U pip
-  pip3 install aqtinstall
-  aqt install-qt mac ios 6.8.3 -O ${QT_INSTALL_DIR} --autodesktop
-  ### OR if it fails for arm64
-  arch -x86_64 aqt install-qt mac ios 6.8.3 -O ${QT_INSTALL_DIR}/6.8.3/ios --autodesktop
+## Troubleshooting
 
-  export QTDIR=${QT_INSTALL_DIR}/5.15.2/ios
-```
+### iOS Common Issues
 
-#### Running the app
-```
-  make run
-```
+1. **CMake Qt5 Error**
+   ```
+   CMake Error at CMakeLists.txt:36 (find_package):
+     By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
+     asked CMake to find a package configuration file provided by "Qt5", but
+     CMake did not find one.
+   ```
+   **Fix**: Ensure `QTDIR` environment variable points to the Qt installation folder.
 
-### Possible issues
+2. **Python Interpreter Error**
+   ```
+   ios/mkspecs/features/uikit/devices.py: /usr/bin/python: bad interpreter: No such file or directory
+   ```
+   **Fix**: Update the Python path in `ios/mkspecs/features/uikit/devices.py`.
 
-```
-scripts/clangWrap.sh
-CMake Error at CMakeLists.txt:36 (find_package):
-  By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
-  asked CMake to find a package configuration file provided by "Qt5", but
-  CMake did not find one.
+3. **Missing distutils**
+   ```
+   ModuleNotFoundError: No module named 'distutils'
+   ```
+   **Fix**: `pip install setuptools`
 
-```
-Fix: Make sure the env variable `QTDIR` points to the qt installation folder
+4. **Invalid CFBundleVersion**
+   ```
+   Simulator device failed to install the application.
+   The application's Info.plist does not contain a valid CFBundleVersion.
+   ```
+   **Fix**: Remove `bin/Status-tablet.app` and run `make run`
 
+5. **FBSOpenApplicationServiceErrorDomain**
+   ```
+   Underlying error (domain=FBSOpenApplicationServiceErrorDomain, code=4):
+   ```
+   **Fix**: In the simulator app, choose `Device -> Erase all content and settings`
 
-```
-ios/mkspecs/features/uikit/devices.py: /usr/bin/python: bad interpreter: No such file or directory
-```
+### Android Common Issues
 
-Fix: Update `ios/mkspecs/features/uikit/devices.py` header to point to your python installation
+1. **PNG Rendering on macOS Emulator**  
+   **Issue**: PNG files won't render on macOS emulator.  
+   **Fix**: Add `setenv("QT_QUICK_BACKEND", "software", 1);` in main.cpp
 
-```
-    from distutils.version import StrictVersion
-ModuleNotFoundError: No module named 'distutils'
-```
+2. **Gradle Crashes**  
+   **Issue**: Gradle crashes during build.  
+   **Fix**: Ensure sufficient RAM is available. A system restart may be needed.
 
-Fix: `pip install setuptools`
+3. **StatusQ Compilation Crashes**  
+   **Issue**: Compiler crashes while compiling StatusQ.  
+   **Fix**: Ensure at least 10GB of free RAM is available.
 
-```
-Simulator device failed to install the application.
-The application's Info.plist does not contain a valid CFBundleVersion.
-Ensure your bundle contains a valid CFBundleVersion.
-```
+## Contributing
 
-Fix: Remove `bin/Status-tablet.app` and run `make run`
+When contributing to the build system:
+1. Test changes on both iOS and Android platforms
+2. Qt6 compatibility is mandatory. Qt5 is nice to have for now
+3. Update this README if necessary
+4. Follow the existing build system patterns
 
-```
-Underlying error (domain=FBSOpenApplicationServiceErrorDomain, code=4):
-```
-
-Fix: In the simulator app choose `Device -> Erase all content and settings`
-
-# Android
-
-#### Prerequisites:
-- Make sure status-desktop can be built
-- Qt 5.15.2 for Android or qt 6.8.3 for Android
-- Clone submodules
-```
-  git submodule update --init --recursive
-```
-
-- JDK 11 (17 for qt6)
-- Android sdk
-- Android NDK 21.3.6528147 (26.1.10909125 for qt6)
-- Android emulator
-- Android cmd line tools
-- Available AVD image
-
-#### Installing qt
-```
-  pip3 install -U pip
-  pip3 install aqtinstall
-  aqt install-qt mac android 5.15.2 -O ${QT_INSTALL_DIR}
-  #For qt6 autodesktop flag is needed
-  #The androiddeployqt is installed in the desktop distribution
-  aqt install-qt mac android 6.8.3 android_arm64-v8a --autodesktop
-
-  export QTDIR=${QT_INSTALL_DIR}/5.15.2/android
-```
-
-Note: These prerequisites can be installed with AndroidStudio
-
-Or by using the command line tools
-```
-sudo apt install openjdk-11-jdk
-sudo apt install google-android-cmdline-tools-13.0-installer
-sdkmanager --update
-sdkmanager "build-tools;35.0.1" "emulator" "platform-tools" "platforms;android-31" "ndk;21.3.6528147"
-
-# create a new AVD image. Using the template with id 70
-avdmanager create avd -n "Test_avd_x64" -k "system-images;android-Baklava;google_apis_playstore;x86_64" -d 70
-
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export ANDROID_HOME=usr/lib/android-sdk
-export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:/usr/lib/android-sdk/platform-tools:$PATH"
-export ANDROID_NDK_HOME=/usr/lib/android-sdk/ndk/21.3.6528147 
-export SDK_PATH="$ANDROID_HOME"
-# default architecture is arm64-v8a
-export ARCH=<android target>
-```
-
-#### Running the app
-```
-  make run
-```
-
-### Known issues
-
-PNG files won't be rendered on macos emulator. This can be fixed by setting the software rendered for qt.
-Add `setenv("QT_QUICK_BACKEND", "software", 1);` in main.cpp
-
-gradle is crashing sometimes: Make sure there's enough RAM. Sometimes a restart is needed
-the compiler is sometimes crashing while compiling statusQ: Make sure at least 10GB free RAM is available
 

--- a/android/qt6/AndroidManifest.xml
+++ b/android/qt6/AndroidManifest.xml
@@ -41,12 +41,14 @@
         android:windowContentOverlay="@null"
         android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
+        android:hasFragileUserData="true"
         android:fullBackupOnly="false">
         <activity
             android:name="org.qtproject.qt.android.bindings.QtActivity"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:launchMode="singleTop"
             android:screenOrientation="landscape"
+            android:resizeableActivity="false"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,75 @@
+# QT Installation Image --------------------------------------------------------
+FROM carlonluca/qt-dev:6.8.3
+
+ENV ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}
+ENV SDK_PATH=${ANDROID_SDK_ROOT}
+ENV PATH=/opt/qt/6.8.3/android_arm64_v8a/bin:${PATH}
+ENV ARCH=arm64
+
+# Install base dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    unzip \
+    sudo \
+    build-essential \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies
+RUN apt update -yq && apt install -yq software-properties-common \
+ && add-apt-repository -y ppa:git-core/ppa \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt update -yq && apt full-upgrade -yq && apt install -yq --no-install-recommends --fix-missing  \
+    gnupg2 openssh-client ca-certificates locales sudo jq curl wget fuse s3cmd file unzip llvm tk-dev xz-utils \
+    git make build-essential pkg-config extra-cmake-modules gcc-9 g++-9 \
+    libgl1-mesa-dev libsm6 libice6 libfontconfig1 libdbus-1-3 libssl-dev libz-dev \
+    zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev unixodbc-dev libpq-dev \
+    libncurses5-dev libncursesw5-dev libpcre3-dev libnss3 \
+    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa libpulse-mainloop-glib0 \
+    gstreamer1.0-pulseaudio libgstreamer-plugins-base1.0-0 \
+    libxext6 libxrender1 libxkbcommon-dev libxkbcommon-x11-dev libxcomposite1 libxtst6 \
+    libxrandr2 libxcursor1 libxi6 libxcb-randr0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    libxcb-render-util0 libxcb-shape0 libxcb-render0 libxcb-xinerama0 \
+    autoconf automake libtool gcc \
+ &&  update-alternatives \
+    --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
+ && apt-get -qq clean
+
+    
+# Installing Golang
+RUN GOLANG_SHA256="736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092" \
+ && GOLANG_TARBALL="go1.22.10.linux-amd64.tar.gz" \
+ && wget -q "https://dl.google.com/go/${GOLANG_TARBALL}" \
+ && echo "${GOLANG_SHA256} ${GOLANG_TARBALL}" | sha256sum -c \
+ && sudo tar -C /usr/local -xzf "${GOLANG_TARBALL}" \
+ && rm "${GOLANG_TARBALL}" \
+ && sudo ln -s /usr/local/go/bin/go /usr/local/bin
+
+# Install Protoc
+RUN PROTOC_SHA256="75d8a9d7a2c42566e46411750d589c51276242d8b6247a5724bac0f9283e05a8" \
+ && PROTOC_TARBALL="protoc-3.20.0-linux-x86_64.zip" \
+ && wget -q "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/${PROTOC_TARBALL}" \
+ && echo "${PROTOC_SHA256} ${PROTOC_TARBALL}" | sha256sum -c \
+ && sudo unzip -d /usr/local "${PROTOC_TARBALL}" \
+ && rm "${PROTOC_TARBALL}"
+
+# Install Protoc-deg-go
+RUN PROTOC_GEN_SHA256="0b2c257938a8cd9ba3506bbdbbaad45e51245b6f9e0743035ade7acf746c6be7" \
+ && PROTOC_GEN_TARBALL="protoc-gen-go.v1.34.1.linux.amd64.tar.gz" \
+ && wget -q "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.34.1/${PROTOC_GEN_TARBALL}" \
+ && echo "${PROTOC_GEN_SHA256} ${PROTOC_GEN_TARBALL}" | sha256sum -c \
+ && sudo tar -C /usr/local/bin -xzf "${PROTOC_GEN_TARBALL}" \
+ && rm "${PROTOC_GEN_TARBALL}"
+
+# Install Go tools needed for the build
+RUN go install github.com/go-bindata/go-bindata/v3/go-bindata@latest \
+ && go install go.uber.org/mock/mockgen@v0.4.0
+
+
+ENV PATH="/root/go/bin:${PATH}"
+
+LABEL description="Build image for the Status-tablet Android APK."

--- a/scripts/Common.mk
+++ b/scripts/Common.mk
@@ -1,0 +1,76 @@
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+HOST_ENV=$(shell printenv)
+OS?=android
+QT_VERSION?=6
+
+$(info ROOT_DIR: $(ROOT_DIR))
+$(info PWD: $(shell pwd))
+
+# verbosity level
+V := 0
+ifeq ($(V), 0)
+  HANDLE_OUTPUT := >/dev/null 2>&1
+endif
+
+# path macros
+BIN_PATH := $(ROOT_DIR)/bin/$(OS)/qt$(QT_VERSION)
+LIB_PATH := $(ROOT_DIR)/lib/$(OS)/qt$(QT_VERSION)
+BUILD_PATH := $(ROOT_DIR)/build/$(OS)/qt$(QT_VERSION)
+SCRIPTS_PATH := $(ROOT_DIR)/scripts
+
+export LIB_DIR=$(LIB_PATH)
+
+WRAPPER_APP?=$(ROOT_DIR)/wrapperApp
+STATUS_DESKTOP?=$(ROOT_DIR)/vendors/status-desktop
+STATUSQ?=$(STATUS_DESKTOP)/ui/StatusQ
+STATUS_GO?=$(STATUS_DESKTOP)/vendor/status-go
+DOTHERSIDE?=$(STATUS_DESKTOP)/vendor/DOtherSide
+OPENSSL?=$(ROOT_DIR)/vendors/OpenSSL-for-iPhone
+QRCODEGEN?=$(STATUS_DESKTOP)/vendor/QR-Code-generator/c
+PCRE?=$(ROOT_DIR)/vendors/pcre-8.45
+
+project_name := Status-tablet
+
+# compile macros
+TARGET_NAME := Status-tablet.$(shell if [ $(OS) = "ios" ]; then echo "app"; else echo "apk"; fi )
+
+TARGET := $(BIN_PATH)/$(TARGET_NAME)
+
+# src files & obj files
+STATUS_DESKTOP_NIM_FILES := $(shell find $(STATUS_DESKTOP)/src -type f \( -iname '*.nim' -o -iname '*.nims' \))
+STATUS_DESKTOP_UI_FILES := $(shell find $(STATUS_DESKTOP)/ui -type f \( -iname 'qmldir' -o -iname '*.qml' -o -iname '*.qrc' \) -not -iname 'resources.qrc' -not -path '$(STATUS_DESKTOP)/ui/StatusQ/*')
+STATUS_Q_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.cpp' -o -iname '*.h' \) -not -iname '*.qrc' -not -iname '*.qml')
+STATUS_Q_UI_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.qml' -o -iname '*.qrc' \))
+STATUS_GO_FILES := $(shell find $(STATUS_GO) -type f)
+STATUS_GO_SCRIPT := $(SCRIPTS_PATH)/buildStatusGo.sh
+DOTHERSIDE_FILES := $(shell find $(DOTHERSIDE) -type f \( -iname '*.cpp' -o -iname '*.h' \))
+OPENSSL_FILES := $(shell find $(OPENSSL)/OpenSSL-for-iOS -type f)
+QRCODEGEN_FILES := $(shell find $(QRCODEGEN) -type f \( -iname '*.c' -o -iname '*.h' \))
+PCRE_FILES := $(shell find $(PCRE) -type f)
+WRAPPER_APP_FILES := $(shell find $(WRAPPER_APP) -type f)
+
+# script files
+STATUS_Q_SCRIPT := $(SCRIPTS_PATH)/buildStatusQ.sh
+STATUS_GO_SCRIPT := $(SCRIPTS_PATH)/buildStatusGo.sh
+DOTHERSIDE_SCRIPT := $(SCRIPTS_PATH)/buildDOtherSide.sh
+OPENSSL_SCRIPT := $(SCRIPTS_PATH)/$(OS)/buildOpenSSL.sh
+QRCODEGEN_SCRIPT := $(SCRIPTS_PATH)/buildQRCodeGen.sh
+PCRE_SCRIPT := $(SCRIPTS_PATH)/buildPCRE.sh
+NIM_STATUS_CLIENT_SCRIPT := $(SCRIPTS_PATH)/buildNimStatusClient.sh
+APP_SCRIPT := $(SCRIPTS_PATH)/buildApp.sh
+RUN_SCRIPT := $(SCRIPTS_PATH)/$(OS)/run.sh
+
+# lib files
+STATUS_GO_LIB := $(LIB_PATH)/libstatus$(LIB_EXT)
+STATUS_Q_LIB := $(LIB_PATH)/libStatusQ$(LIB_SUFFIX)$(LIB_EXT)
+OPENSSL_LIB := $(LIB_PATH)/libssl_1_1$(LIB_EXT)
+QRCODEGEN_LIB := $(LIB_PATH)/libqrcodegen.a
+PCRE_LIB := $(LIB_PATH)/libpcre$(LIB_EXT)
+QZXING_LIB := $(LIB_PATH)/libqzxing.a
+NIM_STATUS_CLIENT_LIB := $(LIB_PATH)/libnim_status_client$(LIB_EXT)
+STATUS_DESKTOP_RCC := $(STATUS_DESKTOP)/ui/resources.qrc
+ifeq ($(OS), ios)
+DOTHERSIDE_LIB := $(LIB_PATH)/libDOtherSideStatic$(LIB_SUFFIX)$(LIB_EXT)
+else
+DOTHERSIDE_LIB := $(LIB_PATH)/libDOtherSide$(LIB_SUFFIX)$(LIB_EXT)
+endif

--- a/scripts/EnvVariables.mk
+++ b/scripts/EnvVariables.mk
@@ -5,6 +5,7 @@ HOST_OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH?=$(shell uname -m)
 # Detect Qt version from qmake
 QT_VERSION?=$(shell qmake -query QT_VERSION | head -c 1 2>/dev/null)
+QT_DIR?=$(shell qmake -query QT_INSTALL_PREFIX)
 
 ifeq ($(OS), ios)
 # iOS
@@ -49,6 +50,7 @@ export ARCH
 export OS
 export HOST_OS
 export QT_VERSION
+export QT_DIR
 
 ifeq ($(OS), ios)
 	export SDK=$(IPHONE_SDK)
@@ -91,7 +93,7 @@ ifeq ($(QMAKE),)
 endif
 $(info QMAKE: $(QMAKE))
 
-RCC := $(shell which rcc)
+RCC := $(shell qmake -query QT_HOST_LIBEXECS)/rcc
 ifeq ($(RCC),)
   $(error rcc not found)
 endif

--- a/scripts/android/run.sh
+++ b/scripts/android/run.sh
@@ -7,8 +7,13 @@ EMULATOR=${EMULATOR:="$ANDROID_SDK_ROOT/emulator/emulator"}
 ADB=${ADB:="$ANDROID_SDK_ROOT/platform-tools/adb"}
 ANDROID_SERIAL=${ANDROID_SERIAL:=""}
 
-if [ "$ANDROID_SDK_ROOT" = "" ]; then
-    echo "ANDROID_SDK_ROOT is not set. Please set ANDROID_SDK_ROOT to the path of your Android SDK."
+if [ "$ADB" = "" ]; then
+    echo "ADB is not set. Please set ADB to the path of your Android SDK."
+    exit 1
+fi
+
+if [ "$EMULATOR" = "" ]; then
+    echo "EMULATOR is not set. Please set EMULATOR to the path of your Android SDK."
     exit 1
 fi
 
@@ -60,12 +65,20 @@ select_device_or_emulator() {
     fi
 }
 
+# Run on the connected device or emulator
 if [ -z "$ANDROID_SERIAL" ]; then
     select_device_or_emulator
 fi
 
 echo "Installing app"
+$ADB -s $ANDROID_SERIAL uninstall im.status.tablet
 $ADB -s $ANDROID_SERIAL install -r $APP
+if [ $? -ne 0 ]; then
+    echo "App installation failed."
+    exit 1
+else
+    echo "App installed successfully."
+fi
 
 echo "App installed. Starting app"
 if [ "$QT_VERSION" = "6" ]; then

--- a/scripts/android/run.sh
+++ b/scripts/android/run.sh
@@ -2,10 +2,18 @@
 
 CWD=$(realpath `dirname $0`)
 APP=${APP:="$CWD/../bin/$OS/Status-tablet.apk"}
+ARCH=${ARCH:="arm64-v8a"}
 ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:=""}
 EMULATOR=${EMULATOR:="$ANDROID_SDK_ROOT/emulator/emulator"}
 ADB=${ADB:="$ANDROID_SDK_ROOT/platform-tools/adb"}
-ANDROID_SERIAL=${ANDROID_SERIAL:=""}
+# Optional params:
+ANDROID_SERIAL=${ANDROID_SERIAL:=""} # Serial number of the device to use to avoid interactive selection
+
+# It's only used if no device is connected and no emulator is defined
+# to create a new emulator
+AVDMANAGER=${AVDMANAGER:="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager"}
+SDKMANAGER=${SDKMANAGER:="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"}
+
 
 if [ "$ADB" = "" ]; then
     echo "ADB is not set. Please set ADB to the path of your Android SDK."
@@ -17,7 +25,43 @@ if [ "$EMULATOR" = "" ]; then
     exit 1
 fi
 
+create_emulator() {
+    # Detect host architecture
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
+        ABI="arm64-v8a"
+    else
+        ABI="x86_64"
+    fi
+
+    API_LEVEL="30"
+    PACKAGE_NAME="system-images;android-${API_LEVEL};google_apis;${ABI}"
+    AVD_NAME="status-default-avd"
+
+    $SDKMANAGER --install "$PACKAGE_NAME" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed to install system image for API level $API_LEVEL and ABI $ABI."
+        exit 1
+    fi
+
+    # Create AVD if not exists
+    if ! $AVDMANAGER list avd | grep -q "$AVD_NAME"; then
+    echo "no" | avdmanager create avd \
+        --name "$AVD_NAME" \
+        --package "$PACKAGE_NAME" \
+        --device "Nexus 10"
+    fi
+}
+
 select_device_or_emulator() {
+
+    # if no device is connected and no emulator defined, create a new emulator
+    if [ -z "$($ADB devices | grep -E 'device$')" ] && [ -z "$($EMULATOR -list-avds)" ]; then
+        echo "No device connected. We're creating a new emulator for you."
+        # Create a new emulator with the default AVD name
+        create_emulator
+    fi
+
     # print all available devices and emulators and let the user select one
     echo "Running devices:"
     device_list=$($ADB devices | awk 'NR>1 && /^[a-zA-Z0-9\-]/ {print NR-1 ": " $1}')

--- a/scripts/buildNimStatusClient.sh
+++ b/scripts/buildNimStatusClient.sh
@@ -9,6 +9,7 @@ LIB_DIR=${LIB_DIR}
 LIB_SUFFIX=${LIB_SUFFIX:=""}
 OS=${OS:="android"}
 HOST_ENV=${HOST_ENV}
+USE_SYSTEM_NIM=${USE_SYSTEM_NIM:="0"}
 
 DESKTOP_VERSION=$(eval cd $STATUS_DESKTOP && ./scripts/version.sh)
 STATUSGO_VERSION=$(eval cd $STATUS_DESKTOP/vendor/status-go && make version --no-print-directory)
@@ -33,7 +34,7 @@ cd $STATUS_DESKTOP
 
 # run make deps-common with sytem environment variables found in $HOST_ENV, not with the one from shell configured for android
 # build nim compiler with host env
-env -i HOME="$HOME" bash -l -c 'make deps-common'
+env -i HOME="$HOME" bash -l -c "make deps-common USE_SYSTEM_NIM=$USE_SYSTEM_NIM V=3 SHELL=/bin/bash"
 
 # setting compile time feature flags
 FEATURE_FLAGS="FLAG_DAPPS_ENABLED=0 FLAG_CONNECTOR_ENABLED=0 FLAG_KEYCARD_ENABLED=0 FLAG_SINGLE_STATUS_INSTANCE_ENABLED=0"

--- a/scripts/buildStatusGo.sh
+++ b/scripts/buildStatusGo.sh
@@ -25,12 +25,12 @@ fi
 echo "Building status-go for $ARCH using compiler: $CC"
 
 cd $STATUS_GO
-make generate
+make generate V=3 SHELL=/bin/sh
 
 mkdir -p build/bin/statusgo-lib
 go run cmd/library/*.go > build/bin/statusgo-lib/main.go
 
-CGO_ENABLED=1 GOOS=$OS GOARCH=$GOARCH \
+GOFLAGS="" CGO_ENABLED=1 GOOS=$OS GOARCH=$GOARCH \
 	go build \
 		-buildmode=$BUILD_MODE \
 		-tags 'gowaku_no_rln nowatchdog disable_torrent' \

--- a/scripts/commonCmakeConfig.sh
+++ b/scripts/commonCmakeConfig.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 ARCH=${ARCH:="x86_64"}
-QTDIR=${QTDIR:="/usr/local/opt/qt"}
+QTDIR=${QTDIR:=$(qmake -query QT_INSTALL_PREFIX)}
 OS=${OS:=ios}
 ANDROID_NDK_HOME=${ANDROID_NDK_HOME:=""}
 

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -1,10 +1,24 @@
 #!/bin/sh
+set -o xtrace
 set -ef pipefail
 
 CWD=$(realpath `dirname $0`)
 APPID=${APPID:=com.statusim.Status}
 APP=${APP:="$CWD/../../bin/Applications/Status-tablet.app"}
-SIMULATOR_INFO=$(xcrun simctl list devices "iPad Pro" | grep -m 1 "iPad Pro")
+echo "APP: $APP"
+SIMULATOR_INFO=$(xcrun simctl list devices "iPad Pro" | grep -m 1 "iPad Pro" || true)
+
+echo "Simulator info: $SIMULATOR_INFO"
+if [ -z "$SIMULATOR_INFO" ]; then
+    echo "No matching simulator found. Creating a new one..."
+    xcrun simctl create "iPad Pro" com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M4-16GB
+    SIMULATOR_INFO=$(xcrun simctl list devices | grep -m 1 "iPad Pro")
+    if [ -z "$SIMULATOR_INFO" ]; then
+        echo "Failed to create or find the simulator. Exiting."
+        exit 1
+    fi
+fi
+
 SIMULATOR_DEVICE_ID=$(echo $SIMULATOR_INFO | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
 SIMULATOR_DEVICE_STATE=$(echo $SIMULATOR_INFO | grep -E -o -i "\((Booted|Shutdown|Shutting Down|Creating|Deleting)\)" | tr -d '()')
 


### PR DESCRIPTION
Adding GH actions support and Docker file for android build.

Adding ContanerBuilds.mk that uses the GH actions to build android without the environemnt setup.

To build on Android:
`make -f ContainerBuilds.mk run`

### Prerequisites (see readme for more details)
- act
- docker

This PR fixes some issues identified by @khushboo